### PR TITLE
Se declara nueva variable

### DIFF
--- a/upload/include/class.api.php
+++ b/upload/include/class.api.php
@@ -16,7 +16,7 @@
 class API {
 
     var $id;
-
+    var $apixxx;
     var $ht;
 
     function __construct($id) {


### PR DESCRIPTION
Esto fue necesario ya que esta variable no fue declarada en ninguna parte de la clase.